### PR TITLE
Fix race condition in withdrawal and improve error handling

### DIFF
--- a/technical-support-test-main/refrigerant/management/commands/withdraw.py
+++ b/technical-support-test-main/refrigerant/management/commands/withdraw.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand
+from django.db.models import F
 from ...models import Vessel
 import threading
+
 
 
 class Command(BaseCommand):
@@ -15,16 +17,18 @@ class Command(BaseCommand):
         barrier = threading.Barrier(2)
 
         def user1():
+            withdraw_amount = 10.0 
             barrier.wait()
-            vessel = Vessel.objects.get(id=1)
-            vessel.content -= 10.0
-            vessel.save()
+            updated = Vessel.objects.filter(id=1, content__gte=withdraw_amount).update(content=F('content') - withdraw_amount)
+            if not updated:
+                self.stdout.write("Vessel is empty, withdrawal not possible.")
 
         def user2():
+            withdraw_amount = 10.0 
             barrier.wait()
-            vessel = Vessel.objects.get(id=1)
-            vessel.content -= 10.0
-            vessel.save()
+            updated = Vessel.objects.filter(id=1, content__gte=withdraw_amount).update(content=F('content') - withdraw_amount)
+            if not updated:
+                self.stdout.write("Vessel is empty, withdrawal not possible.")
 
         t1 = threading.Thread(target=user1)
         t2 = threading.Thread(target=user2)


### PR DESCRIPTION
# Problem

The withdrawal simulation was affected by a **lost update bug**.  
When two users withdrew 10 Kg each concurrently, only one withdrawal was reflected, reducing the vessel by 10 Kg instead of 20 Kg.

Additionally, users could attempt withdrawals from an **empty vessel**, causing **database-level exceptions** instead of helpful error messages.

# Solution

- Implemented **atomic updates** using Django `F` expressions, ensuring correct behavior even under concurrency.  
- Added **safeguards** to prevent withdrawals when the vessel is empty or has insufficient content.  
- Enhanced user experience with **clear messages** instead of database errors.

# Results

- Two concurrent withdrawals now correctly reduce content by **20 Kg total**.  
- Users receive **helpful feedback** if the vessel is empty or content is insufficient.
